### PR TITLE
Easy SelectionTools, started CorrectionTools

### DIFF
--- a/TopAnalysis/bin/analysisWrapper.cc
+++ b/TopAnalysis/bin/analysisWrapper.cc
@@ -56,7 +56,10 @@ int main(int argc, char* argv[])
   if(normF)
     {
       normH=(TH1F *)normF->Get(normTag);
-      if(normH) normH->SetDirectory(0);
+      if(normH) {
+        normH->SetDirectory(0);
+        normH->SetTitle(normTag);
+      }
       normF->Close();
     }
   if(normH==0)

--- a/TopAnalysis/interface/BtagUncertaintyComputer.h
+++ b/TopAnalysis/interface/BtagUncertaintyComputer.h
@@ -36,7 +36,7 @@ class BTagSFUtil{
   BTagSFUtil( int seed=0 );
   ~BTagSFUtil();
     
-  void modifyBTagsWithSF( bool& isBTagged, float Btag_SF = 0.98, float Btag_eff = 1.0);
+  bool modifyBTagsWithSF( bool& isBTagged, float Btag_SF = 0.98, float Btag_eff = 1.0);
 
 
  private:

--- a/TopAnalysis/interface/CorrectionTools.h
+++ b/TopAnalysis/interface/CorrectionTools.h
@@ -1,0 +1,76 @@
+#ifndef _correction_tools_h_
+#define _correction_tools_h_
+
+#include <vector>
+
+#include "TString.h"
+
+#include "TopLJets2015/TopAnalysis/interface/MiniEvent.h"
+#include "TopLJets2015/TopAnalysis/interface/BtagUncertaintyComputer.h"
+
+#include "CondFormats/BTauObjects/interface/BTagCalibration.h"
+#include "CondFormats/BTauObjects/interface/BTagCalibrationReader.h"
+
+MiniEvent_t smearJetEnergies(MiniEvent_t ev, TString option = "") {
+  for (int k = 0; k < ev.nj; k++) {
+    TLorentzVector jp4;
+    jp4.SetPtEtaPhiM(ev.j_pt[k],ev.j_eta[k],ev.j_phi[k],ev.j_mass[k]);
+
+    //smear jet energy resolution for MC
+    float genJet_pt(0);
+    if(ev.j_g[k]>-1) genJet_pt = ev.g_pt[ ev.j_g[k] ];
+    if(!ev.isData && genJet_pt>0) {
+      float jerSmear=getJetResolutionScales(jp4.Pt(),jp4.Eta(),genJet_pt)[0];
+      jp4 *= jerSmear;
+      ev.j_pt[k]   = jp4.Pt();
+      ev.j_eta[k]  = jp4.Eta();
+      ev.j_phi[k]  = jp4.Phi();
+      ev.j_mass[k] = jp4.M();
+    }
+  }
+  
+  return ev;
+}
+
+MiniEvent_t addBTagDecisions(MiniEvent_t ev) {
+  for (int k = 0; k < ev.nj; k++) {
+    ev.j_btag[k] = (ev.j_csv[k] > 0.800);
+  }
+  
+  return ev;
+}
+
+MiniEvent_t updateBTagDecisions(MiniEvent_t ev, BTagCalibrationReader* sfbReader, BTagCalibrationReader* sflReader, std::map<TString, TGraphAsymmErrors*> expBtagEff, std::map<TString, TGraphAsymmErrors*> expBtagEffPy8, BTagSFUtil* myBTagSFUtil, TString option = "") {
+  for (int k = 0; k < ev.nj; k++) {
+    TLorentzVector jp4;
+    jp4.SetPtEtaPhiM(ev.j_pt[k],ev.j_eta[k],ev.j_phi[k],ev.j_mass[k]);
+
+    bool isBTagged(ev.j_btag[k]);
+    if(!ev.isData) {
+      float jptForBtag(jp4.Pt()>1000. ? 999. : jp4.Pt()), jetaForBtag(fabs(jp4.Eta()));
+      float expEff(1.0), jetBtagSF(1.0);
+      if(abs(ev.j_hadflav[k])==4) {         
+        expEff    = expBtagEff["c"]->Eval(jptForBtag); 
+        jetBtagSF = sfbReader->eval( BTagEntry::FLAV_C, jetaForBtag, jptForBtag);
+        jetBtagSF *= expEff>0 ? expBtagEffPy8["c"]->Eval(jptForBtag)/expBtagEff["c"]->Eval(jptForBtag) : 0.;
+      }
+      else if(abs(ev.j_hadflav[k])==5) { 
+        expEff    = expBtagEff["b"]->Eval(jptForBtag); 
+        jetBtagSF = sfbReader->eval( BTagEntry::FLAV_B, jetaForBtag, jptForBtag);
+        jetBtagSF *= expEff>0 ? expBtagEffPy8["b"]->Eval(jptForBtag)/expBtagEff["b"]->Eval(jptForBtag) : 0.;
+      }
+      else {
+        expEff    = expBtagEff["udsg"]->Eval(jptForBtag);
+        jetBtagSF = sflReader->eval( BTagEntry::FLAV_UDSG, jetaForBtag, jptForBtag);
+        jetBtagSF *= expEff> 0 ? expBtagEffPy8["udsg"]->Eval(jptForBtag)/expBtagEff["udsg"]->Eval(jptForBtag) : 0.;
+      }
+      
+      //updated b-tagging decision with the data/MC scale factor
+      ev.j_btag[k] = myBTagSFUtil->modifyBTagsWithSF(isBTagged, jetBtagSF, expEff);
+    }
+  }
+  
+  return ev;
+}
+
+#endif

--- a/TopAnalysis/interface/LeptonEfficiencyWrapper.h
+++ b/TopAnalysis/interface/LeptonEfficiencyWrapper.h
@@ -9,6 +9,8 @@
 #include <vector>
 #include <map>
 
+#include "TopLJets2015/TopAnalysis/interface/ObjectTools.h"
+
 typedef std::pair<float,float> EffCorrection_t;
 
 class LeptonEfficiencyWrapper 
@@ -16,7 +18,9 @@ class LeptonEfficiencyWrapper
  public:
   LeptonEfficiencyWrapper(bool isData,TString era);
   EffCorrection_t getTriggerCorrection(std::vector<int> pdgId,std::vector<TLorentzVector> leptons);
+  EffCorrection_t getTriggerCorrection(std::vector<Particle> leptons);
   EffCorrection_t getOfflineCorrection(int pdgId,float pt,float eta);
+  EffCorrection_t getOfflineCorrection(Particle lepton);
   ~LeptonEfficiencyWrapper();  
  private:
   void init(TString era);

--- a/TopAnalysis/interface/MiniEvent.h
+++ b/TopAnalysis/interface/MiniEvent.h
@@ -40,6 +40,7 @@ struct MiniEvent_t
   Int_t nj;
   Float_t j_pt[200],j_eta[200],j_phi[200],j_mass[200],j_area[200],j_rawsf[200];
   Float_t j_csv[200],j_cvsl[200],j_cvsb[200],j_vtxmass[200],j_vtx3DVal[200],j_vtx3DSig[200],j_puid[200],j_vtxpx[200],j_vtxpy[200],j_vtxpz[200];
+  Bool_t j_btag[200];
   Int_t j_vtxNtracks[200],j_flav[200],j_pid[200],j_hadflav[200],j_g[200];
 
   //met

--- a/TopAnalysis/interface/ObjectTools.h
+++ b/TopAnalysis/interface/ObjectTools.h
@@ -9,8 +9,8 @@
 class Particle {
   
   public:
-    Particle(TLorentzVector p4, int charge = 1, double puppi = 1)
-      : p4_(p4), charge_(charge), puppi_(puppi) {}
+    Particle(TLorentzVector p4, int charge, int id, double puppi = 1)
+      : p4_(p4), charge_(charge), id_(id), puppi_(puppi) {}
     
     double px()     { return p4_.Px();  }
     double py()     { return p4_.Py();  }
@@ -20,15 +20,18 @@ class Particle {
     double eta()    { return p4_.Eta(); }
     double phi()    { return p4_.Phi(); }
     double energy() { return p4_.E(); }
+    double m()      { return p4_.M(); }
     double mass()   { return p4_.M(); }
     TLorentzVector p4()       { return p4_; }
     TLorentzVector momentum() { return p4_; }
     int charge()    { return charge_; }
+    int id()        { return id_; }
     double puppi()  { return puppi_; }
   
   private:
     TLorentzVector p4_;
     int charge_;
+    int id_;
     double puppi_;
 };
 
@@ -46,6 +49,7 @@ class Jet {
       : p4_(p4), csv_(csv), idx_(idx) {}
     ~Jet() {}
     
+    double pt()     { return p4_.Pt();  }
     TLorentzVector p4()       { return p4_; }
     TLorentzVector momentum() { return p4_; }
     std::vector<Particle> particles() { return particles_; }

--- a/TopAnalysis/interface/SelectionTools.h
+++ b/TopAnalysis/interface/SelectionTools.h
@@ -1,0 +1,135 @@
+#ifndef _selection_tools_h_
+#define _selection_tools_h_
+
+#include <vector>
+
+#include "TString.h"
+
+#include "TopLJets2015/TopAnalysis/interface/MiniEvent.h"
+#include "TopLJets2015/TopAnalysis/interface/ObjectTools.h"
+
+std::vector<Particle> getGoodLeptons(MiniEvent_t ev, double tightMinPt = 20., double tightMaxEta = 2.5, bool vetoLoose = false, double looseMinPt = 15., double looseMaxEta = 2.5) {
+  std::vector<Particle> leptons;
+  
+  for (int il=0; il<ev.nl; il++) {
+	  bool passTightKin(ev.l_pt[il]>tightMinPt && fabs(ev.l_eta[il])<tightMaxEta);
+    bool passLooseKin(ev.l_pt[il]>looseMinPt && fabs(ev.l_eta[il])<looseMaxEta);
+	  bool passTightId (ev.l_id[il]==13 ? (ev.l_pid[il]>>1)&0x1 : (ev.l_pid[il]>>2)&0x1);
+    bool passTightIso(ev.l_id[il]==13 ?  ev.l_relIso[il]<0.15 : (ev.l_pid[il]>>1)&0x1);
+    bool passLooseIso(ev.l_id[il]==13 ?  ev.l_relIso[il]<0.25 : (ev.l_pid[il]   )&0x1);
+	  if(passTightKin && passTightId && passTightIso) {
+      TLorentzVector lp4;
+      lp4.SetPtEtaPhiM(ev.l_pt[il],ev.l_eta[il],ev.l_phi[il],ev.l_mass[il]);
+      leptons.push_back(Particle(lp4, ev.l_charge[il], ev.l_id[il]));
+    }
+    else if(vetoLoose && passLooseKin && passLooseIso) {
+      return {};
+    }
+	}
+  
+  return leptons;
+}
+
+std::vector<Jet> getGoodJets(MiniEvent_t ev, double minPt = 30., double maxEta = 2.4, std::vector<Particle> leptons = {}) {
+  std::vector<Jet> jets;
+  
+  for (int k=0; k<ev.nj; k++) {
+    TLorentzVector jp4;
+    jp4.SetPtEtaPhiM(ev.j_pt[k],ev.j_eta[k],ev.j_phi[k],ev.j_mass[k]);
+
+    //cross clean with leptons
+    bool overlapsWithLepton(false);
+    for (auto& lepton : leptons) {
+      if(jp4.DeltaR(lepton.p4())<0.4) overlapsWithLepton=true;
+    }
+    if(overlapsWithLepton) continue;
+    
+    //jet kinematic selection
+    if(jp4.Pt() < minPt || abs(jp4.Eta()) > maxEta) continue;
+
+    //flavor based on b tagging
+    int flavor = 0;
+    if (ev.j_btag[k]) {
+      flavor = 5;
+    }
+    
+    Jet jet(jp4, flavor, k);
+    
+    //fill jet constituents
+    for (int p = 0; p < ev.npf; p++) {
+      if (ev.pf_j[p] == k) {
+        TLorentzVector pp4;
+        pp4.SetPtEtaPhiM(ev.pf_pt[p],ev.pf_eta[p],ev.pf_phi[p],ev.pf_m[p]);
+        jet.addParticle(Particle(pp4, ev.pf_c[p], ev.pf_id[p], ev.pf_puppiWgt[p]));
+        if (ev.pf_c[p] != 0) jet.addTrack(pp4, ev.pf_id[p]);
+      }
+    }
+    
+    jets.push_back(jet);
+  }
+  
+  //additional jet-jet information
+  for (unsigned int i = 0; i < jets.size(); i++) {
+    for (unsigned int j = i+1; j < jets.size(); j++) {
+      //flag jet-jet overlaps
+      if (jets[i].p4().DeltaR(jets[j].p4()) < 0.8) {
+        jets[i].setOverlap(1);
+        jets[j].setOverlap(1);
+      }
+      //flag non-b jets as part of W boson candidates: flavor 0->1
+      if (jets[i].flavor()==5 or jets[j].flavor()==5) continue;
+      TLorentzVector wCand = jets[i].p4() + jets[j].p4();
+      if (abs(wCand.M()-80.4) < 15.) {
+        jets[i].setFlavor(1);
+        jets[j].setFlavor(1);
+      }
+    }
+  }
+  
+  return jets;
+}
+
+TString getChannel(MiniEvent_t ev, TString filename, std::vector<Particle> leptons) {
+  bool requireEETriggers(false);
+  if(ev.isData && filename.Contains("DoubleEG"))       requireEETriggers=true;
+  bool requireMMTriggers(false);
+  if(ev.isData && filename.Contains("DoubleMuon"))     requireMMTriggers=true;
+  bool requireEMTriggers(false);
+  if(ev.isData && filename.Contains("MuonEG"))         requireEMTriggers=true;
+  bool requireETriggers(false);
+  if(ev.isData && filename.Contains("SingleElectron")) requireETriggers=true;
+  bool requireMTriggers(false);
+  if(ev.isData && filename.Contains("SingleMuon"))     requireMTriggers=true;
+  
+  //check if triggers have fired
+  bool hasEETrigger(requireEETriggers && ((ev.elTrigger>>1)&0x1)!=0 || ((ev.elTrigger>>4)&0x1)!=0);
+  bool hasMMTrigger(requireMMTriggers && ((ev.muTrigger>>2)&0x3)!=0);
+  bool hasEMTrigger(requireEMTriggers && ((ev.elTrigger>>2)&0x3)!=0);
+  bool hasETrigger (requireETriggers  && ((ev.elTrigger>>0)&0x1)!=0);
+  bool hasMTrigger (requireMTriggers  && ((ev.muTrigger>>0)&0x3)!=0);
+  if(!ev.isData) { 
+    hasEETrigger = true;
+    hasMMTrigger = true;
+    hasEMTrigger = true;
+    hasETrigger  = true;
+    hasMTrigger  = true;
+  }
+
+  //decide the channel
+  TString chTag("");
+  if(leptons.size()>=2) {
+    if      (abs(leptons[0].id()*leptons[1].id())==11*13 && hasEMTrigger) chTag = "EM";
+    else if (abs(leptons[0].id()*leptons[1].id())==13*13 && hasMMTrigger) chTag = "MM";
+    else if (abs(leptons[0].id()*leptons[1].id())==11*11 && hasEETrigger) chTag = "EE";
+  }
+  if(leptons.size()==1) {
+    if      (abs(leptons[0].id())==13 && hasMTrigger) chTag = "M";
+    else if (abs(leptons[0].id())==11 && hasETrigger) chTag = "E";
+  }
+  
+  return chTag;
+}
+
+
+
+#endif

--- a/TopAnalysis/plugins/MiniAnalyzer.cc
+++ b/TopAnalysis/plugins/MiniAnalyzer.cc
@@ -645,6 +645,7 @@ void MiniAnalyzer::recAnalysis(const edm::Event& iEvent, const edm::EventSetup& 
 	  break;
 	}	 
       ev_.j_csv[ev_.nj]=j->bDiscriminator("pfCombinedInclusiveSecondaryVertexV2BJetTags");
+      ev_.j_btag[ev_.nj]=(ev_.j_csv[ev_.nj]>0.800);
       ev_.j_cvsl[ev_.nj]=j->bDiscriminator("pfCombinedCvsLJetTags");
       ev_.j_cvsb[ev_.nj]=j->bDiscriminator("pfCombinedCvsBJetTags");
       ev_.j_vtxpx[ev_.nj]=j->userFloat("vtxPx");

--- a/TopAnalysis/src/BtagUncertaintyComputer.cc
+++ b/TopAnalysis/src/BtagUncertaintyComputer.cc
@@ -13,10 +13,11 @@ BTagSFUtil::~BTagSFUtil() {
 }
 
 
-void BTagSFUtil::modifyBTagsWithSF(bool& isBTagged, float tag_SF, float tag_Eff){
+bool BTagSFUtil::modifyBTagsWithSF(bool& isBTagged, float tag_SF, float tag_Eff){
   bool newBTag = isBTagged;
   newBTag = applySF(isBTagged, tag_SF, tag_Eff);
   isBTagged = newBTag;
+  return newBTag;
 }
 
 

--- a/TopAnalysis/src/LeptonEfficiencyWrapper.cc
+++ b/TopAnalysis/src/LeptonEfficiencyWrapper.cc
@@ -215,6 +215,19 @@ EffCorrection_t LeptonEfficiencyWrapper::getTriggerCorrection(std::vector<int> p
 }
 
 //
+EffCorrection_t LeptonEfficiencyWrapper::getTriggerCorrection(std::vector<Particle> leptons)
+{
+  std::vector<int> pdgId;
+  std::vector<TLorentzVector> leptonp4;
+  for (auto& lepton : leptons)
+    {
+      pdgId.push_back(lepton.id());
+      leptonp4.push_back(lepton.p4());
+    }
+  return getTriggerCorrection(pdgId, leptonp4);
+}
+
+//
 EffCorrection_t LeptonEfficiencyWrapper::getOfflineCorrection(int pdgId,float pt,float eta)
 {
   EffCorrection_t corr(1.0,0.0);
@@ -258,6 +271,12 @@ EffCorrection_t LeptonEfficiencyWrapper::getOfflineCorrection(int pdgId,float pt
     }
 
   return corr;
+}
+
+//
+EffCorrection_t LeptonEfficiencyWrapper::getOfflineCorrection(Particle lepton)
+{
+  return getOfflineCorrection(lepton.id(),lepton.pt(),lepton.eta());
 }
 
 LeptonEfficiencyWrapper::~LeptonEfficiencyWrapper()

--- a/TopAnalysis/src/MiniEvent.cc
+++ b/TopAnalysis/src/MiniEvent.cc
@@ -81,6 +81,7 @@ void createMiniEventTree(TTree *t,MiniEvent_t &ev)
   t->Branch("j_phi",      ev.j_phi,     "j_phi[nj]/F");
   t->Branch("j_mass",     ev.j_mass,     "j_mass[nj]/F");
   t->Branch("j_csv",      ev.j_csv,     "j_csv[nj]/F");
+  t->Branch("j_btag",     ev.j_btag,    "j_btag[nj]/O");
   t->Branch("j_csvl",     ev.j_cvsl,     "j_cvsl[nj]/F");
   t->Branch("j_cvsb",     ev.j_cvsb,     "j_cvsb[nj]/F");
   t->Branch("j_vtxpx",    ev.j_vtxpx, "j_vtxpx[nj]/F");
@@ -195,6 +196,7 @@ void attachToMiniEventTree(TTree *t,MiniEvent_t &ev,bool full)
   t->SetBranchAddress("j_phi",      ev.j_phi);
   t->SetBranchAddress("j_mass",     ev.j_mass);
   t->SetBranchAddress("j_csv",      ev.j_csv);
+  t->SetBranchAddress("j_btag",     ev.j_btag);
   t->SetBranchAddress("j_csvl",     ev.j_cvsl);
   t->SetBranchAddress("j_cvsb",     ev.j_cvsb);
   t->SetBranchAddress("j_vtxpx",    ev.j_vtxpx);


### PR DESCRIPTION
* Dilepton and lepton+jets selection can be done with just a few function calls now (contained in SelectionTools.h), see TOPJetShapes.cc. A convenient jet vector is provided but selection is still left to the analysis (to enable analyses without jet criteria in dilepton).
* I started CorrectionTools.h to contain necessary corrections to either data or MC (or maybe split into Data/MCCorrectionTools.h). The functions are called before selection, take the whole MiniEvent + other parameters as input and return a whole MiniEvent for undisturbed processing afterwards.
* Planned: UncertaintyTools in same spirit as CorrectionTools
* Need to come up with a nicely usable interface to store weights

Please merge at any convenient point in time but before branches start to diverge 🙈 