### PR TITLE
Allow to run with a list of systematic variations

### DIFF
--- a/TopAnalysis/bin/analysisWrapper.cc
+++ b/TopAnalysis/bin/analysisWrapper.cc
@@ -23,6 +23,7 @@ void printHelp()
        << "\t --charge  - charge selection to apply" << endl
        << "\t --flav    - flavour selection to apply" << endl
        << "\t --runSysts - activate running systematics" << endl
+       << "\t --systVar  - specify single systematic variation" << endl
        << "\t --era      - era directory to use for corrections, uncertainties" << endl
        << "\t --normTag  - normalization tag" << endl
        << "\t --method   - method to run" << endl;
@@ -32,13 +33,14 @@ void printHelp()
 int main(int argc, char* argv[])
 {
   //get input arguments
-  TString in(""),out(""),era(""),normTag(""),method("");
+  TString in(""),out(""),era(""),normTag(""),method(""),systVar("");
   bool runSysts(false),debug(false);
   int channel(0),charge(0),flav(0);
   for(int i=1;i<argc;i++){
     string arg(argv[i]);
     if(arg.find("--help") !=string::npos)                     { printHelp(); return -1;} 
     else if(arg.find("--runSysts")!=string::npos )            { runSysts=true;  }
+    else if(arg.find("--systVar")!=string::npos && i+1<argc)  { systVar=argv[i+1]; i++;}
     else if(arg.find("--channel")!=string::npos && i+1<argc)  { sscanf(argv[i+1],"%d",&channel); i++;}
     else if(arg.find("--charge")!=string::npos && i+1<argc)   { sscanf(argv[i+1],"%d",&charge); i++;}
     else if(arg.find("--flav")!=string::npos && i+1<argc)     { sscanf(argv[i+1],"%d",&flav); i++;}
@@ -87,7 +89,7 @@ int main(int argc, char* argv[])
   else if(method=="TOP-HIForest::RunTop16023")               RunTop16023(in,out,channel,charge,normH,runSysts,era);
   else if(method=="TOP-HIForest::RunToppPb")                    RunToppPb(in,out,channel,charge,normH,runSysts,era);
   else if(method=="TOP-UE::RunTopUE")                      RunTopUE(in,out,channel,charge,SelectionTool::FlavourSplitting(flav),normH,runSysts,era);
-  else if(method=="TOPJetShape::RunTopJetShape")           RunTopJetShape(in,out,channel,charge,SelectionTool::FlavourSplitting(flav),normH,runSysts,era,debug);
+  else if(method=="TOPJetShape::RunTopJetShape")           RunTopJetShape(in,out,channel,charge,SelectionTool::FlavourSplitting(flav),normH,runSysts,systVar,era,debug);
   else if(method=="TOPSynchExercise::RunTOPSynchExercise") RunTOPSynchExercise(in,out,debug);
   else
     {

--- a/TopAnalysis/interface/TOPJetShape.h
+++ b/TopAnalysis/interface/TOPJetShape.h
@@ -20,7 +20,7 @@ struct TopJetShapeEvent_t
   Int_t nw, nl, ngl, nj, ngj;
   Int_t gen_sel, reco_sel;
   
-  Float_t weight[10];
+  Float_t weight[1000];
   
   Float_t l_pt[5], l_eta[5], l_phi[5], l_m[5];
   Int_t l_id[5];

--- a/TopAnalysis/interface/TOPJetShape.h
+++ b/TopAnalysis/interface/TOPJetShape.h
@@ -12,6 +12,7 @@ void RunTopJetShape(TString filename,
 		    SelectionTool::FlavourSplitting flavourSplitting,
 		    TH1F *normH, 
 		    Bool_t runSysts,
+		    TString systVar,
 		    TString era,
 		    Bool_t debug=false);
 

--- a/TopAnalysis/scripts/runLocalAnalysis.py
+++ b/TopAnalysis/scripts/runLocalAnalysis.py
@@ -14,7 +14,7 @@ Wrapper to be used when run in parallel
 """
 def RunMethodPacked(args):
 
-    method,inF,outF,channel,charge,flav,runSysts,era,tag,debug=args
+    method,inF,outF,channel,charge,flav,runSysts,systVar,era,tag,debug=args
     print 'Running ',method,' on ',inF
     print 'Output file',outF
     print 'Selection ch=',channel,' charge=',charge,' flavSplit=',flav,' systs=',runSysts
@@ -22,14 +22,8 @@ def RunMethodPacked(args):
     print 'Corrections will be retrieved for era=',era
 
     try:
-        cmd='analysisWrapper --era %s --normTag %s --in %s --out %s --method %s --charge %d --channel %d --flav %d '%(era,
-                                                                                                                      tag,
-                                                                                                                      inF,
-                                                                                                                      outF,
-                                                                                                                      method,
-                                                                                                                      charge,
-                                                                                                                      channel,
-                                                                                                                      flav)
+        cmd='analysisWrapper --era %s --normTag %s --in %s --out %s --method %s --charge %d --channel %d --flav %d --systVar %s'\
+            %(era, tag, inF, outF, method, charge, channel, flav, systVar)
         if runSysts : cmd += ' --runSysts'
         if debug : cmd += ' --debug'
         print(cmd)
@@ -54,6 +48,7 @@ def main():
     parser.add_option('-o', '--out',         dest='output',      help='output directory (or file if single file to process)  [%default]',  default='analysis', type='string')
     parser.add_option(      '--only',        dest='only',        help='csv list of samples to process  [%default]',             default=None,       type='string')
     parser.add_option(      '--runSysts',    dest='runSysts',    help='run systematics  [%default]',                            default=False,      action='store_true')
+    parser.add_option(      '--systVar',     dest='systVar',     help='single systematic variation  [%default]',   default='nominal',       type='string')
     parser.add_option(      '--debug',       dest='debug',      help='debug mode  [%default]',                            default=False,      action='store_true')
     parser.add_option(      '--flav',        dest='flav',        help='split according to heavy flavour content  [%default]',   default=0,          type=int)
     parser.add_option(      '--ch',          dest='channel',     help='channel  [%default]',                                    default=13,         type=int)
@@ -69,6 +64,12 @@ def main():
     onlyList=[]
     try:
         onlyList=opt.only.split(',')
+    except:
+        pass
+    #parse list of systematic variations
+    varList=[]
+    try:
+        varList=opt.systVar.split(',')
     except:
         pass
 
@@ -89,8 +90,10 @@ def main():
     if '.root' in opt.input:
         inF=opt.input
         if '/store/' in inF and not 'root:' in inF : inF='root://eoscms//eos/cms'+opt.input        
-        outF=opt.output
-        task_list.append( (opt.method,inF,outF,opt.channel,opt.charge,opt.flav,opt.runSysts,opt.era,opt.tag,opt.debug) )
+        for systVar in varList:
+            if systVar == 'nominal': outF=opt.output
+            else: outF=opt.output[:-5]+'_'+systVar+'.root'
+            task_list.append( (opt.method,inF,outF,opt.channel,opt.charge,opt.flav,opt.runSysts,systVar,opt.era,opt.tag,opt.debug) )
     else:
 
         inputTags=getEOSlslist(directory=opt.input,prepend='')
@@ -120,11 +123,13 @@ def main():
             
             for ifile in xrange(0,len(input_list)):
                 inF=input_list[ifile]
-                outF=os.path.join(opt.output,'Chunks','%s_%d.root' %(tag,ifile))
-                if (opt.skipexisting and os.path.isfile(outF)):
-                    nexisting += 1
-                    continue
-                task_list.append( (opt.method,inF,outF,opt.channel,opt.charge,opt.flav,opt.runSysts,opt.era,tag,opt.debug) )
+                for systVar in varList:
+                    if systVar == 'nominal': os.path.join(opt.output,'Chunks','%s_%d.root' %(tag,ifile))
+                    else: outF=os.path.join(opt.output,'Chunks','%s_%s_%d.root' %(tag,systVar,ifile))
+                    if (opt.skipexisting and os.path.isfile(outF)):
+                        nexisting += 1
+                        continue
+                    task_list.append( (opt.method,inF,outF,opt.channel,opt.charge,opt.flav,opt.runSysts,systVar,opt.era,tag,opt.debug) )
             if (opt.skipexisting and nexisting): print '--skipexisting: skipping %d of %d tasks as files already exist'%(nexisting,len(input_list))
 
     #run the analysis jobs
@@ -154,14 +159,8 @@ def main():
             cfg.write('eval `scram r -sh`\n')
             cfg.write('cd ${WORKDIR}\n')
             localOutF=os.path.basename(outF)
-            runOpts='-i %s -o ${WORKDIR}/%s --charge %d --ch %d --era %s --tag %s --flav %d --method %s'%(inF,
-                                                                                                      localOutF,
-                                                                                                      charge,
-                                                                                                      channel,
-                                                                                                      era,
-                                                                                                      tag,
-                                                                                                      flav,
-                                                                                                      method)
+            runOpts='-i %s -o ${WORKDIR}/%s --charge %d --ch %d --era %s --tag %s --flav %d --method %s --systVar %s'\
+                    %(inF, localOutF, charge, channel, era, tag, flav, method, systVar)
             if runSysts : runOpts += ' --runSysts'
             if debug :    runOpts += ' --debug'
             cfg.write('python %s/src/TopLJets2015/TopAnalysis/scripts/runLocalAnalysis.py %s\n'%(cmsswBase,runOpts))

--- a/TopAnalysis/src/TOPJetShape.cc
+++ b/TopAnalysis/src/TOPJetShape.cc
@@ -128,33 +128,33 @@ void RunTopJetShape(TString filename,
   std::map<TString, TH2 *> all2dPlots;
   allPlots["puwgtctr"] = new TH1F("puwgtctr","Weight sums",2,0,2);
 
-  std::vector<TString> stageVec = { "s1", "s2", "s3", "s4" };
-  std::vector<TString> chTags = { "", "E", "M" };
+  std::vector<TString> stageVec = { "0_pre", "1_1l", "2_1l4j", "3_1l4j2b", "4_1l4j2b2w" };
+  std::vector<TString> chTags = { "L", "E", "M" };
   for(auto& stage : stageVec) {
     for(auto& channel : chTags) {  
-      TString tag(stage+channel);
+      TString tag(channel+stage+"_");
       
       if(ratevsrunH)
-        allPlots["ratevsrun_"+tag] = (TH1 *)ratevsrunH->Clone("ratevsrun_"+tag);
-      allPlots["nvtx_"+tag]   = new TH1F("nvtx_"+tag,";Vertex multiplicity;Events",30,0,30);
-      allPlots["nleps_"+tag]  = new TH1F("nleps_"+tag,";Lepton multiplicity;Events",5,-0.5,4.5);
-      allPlots["njets_"+tag]  = new TH1F("njets_"+tag,";Jet multiplicity;Events",10,-0.5,9.5);
-      allPlots["nbjets_"+tag] = new TH1F("nbjets_"+tag,";b jet multiplicity;Events",5,-0.5,4.5);
-      allPlots["nwjets_"+tag] = new TH1F("nwjets_"+tag,";W jet multiplicity;Events",10,-0.5,9.5);
-      allPlots["wcandm_"+tag] = new TH1F("wcandm_"+tag,";W candidate mass;W candidates",60,0,300);
-      allPlots["tcandm_"+tag] = new TH1F("tcandm_"+tag,";top candidate mass;top candidates",70,50,400);
-      allPlots["tcandwcutm_"+tag] = new TH1F("tcandwcutm_"+tag,";top candidate mass;top candidates (W cut)",70,50,400);
+        allPlots[tag+"ratevsrun"] = (TH1 *)ratevsrunH->Clone("ratevsrun_"+tag);
+      allPlots[tag+"nvtx"]   = new TH1F(tag+"nvtx",";Vertex multiplicity;Events",30,0,30);
+      allPlots[tag+"nleps"]  = new TH1F(tag+"nleps",";Lepton multiplicity;Events",5,-0.5,4.5);
+      allPlots[tag+"njets"]  = new TH1F(tag+"njets",";Jet multiplicity;Events",10,-0.5,9.5);
+      allPlots[tag+"nbjets"] = new TH1F(tag+"nbjets",";b jet multiplicity;Events",5,-0.5,4.5);
+      allPlots[tag+"nwjets"] = new TH1F(tag+"nwjets",";W jet multiplicity;Events",10,-0.5,9.5);
+      allPlots[tag+"wcandm"] = new TH1F(tag+"wcandm",";W candidate mass;W candidates",60,0,300);
+      allPlots[tag+"tcandm"] = new TH1F(tag+"tcandm",";top candidate mass;top candidates",70,50,400);
+      allPlots[tag+"tcandwcutm"] = new TH1F(tag+"tcandwcutm",";top candidate mass;top candidates (W cut)",70,50,400);
       for(int i=0; i<2; i++) {
         TString pf(Form("l%d",i));          
-        allPlots[pf+"pt_"+tag]  = new TH1F(pf+"pt_"+tag,";Lepton p_{t} [GeV];Events",50,0,250);
-        allPlots[pf+"eta_"+tag]  = new TH1F(pf+"eta_"+tag,";Lepton pseudo-rapidity;Events",50,-2.5,2.5);
+        allPlots[tag+pf+"pt"]   = new TH1F(tag+pf+"pt",";Lepton p_{t} [GeV];Events",50,0,250);
+        allPlots[tag+pf+"eta"]  = new TH1F(tag+pf+"eta",";Lepton pseudo-rapidity;Events",50,-2.5,2.5);
       }
       for(int i=0; i<6; i++) {
         TString pf(Form("j%d",i));
-        allPlots[pf+"pt_"+tag]  = new TH1F(pf+"pt_"+tag,";Jet transverse momentum [GeV];Events",50,0,250);
-        allPlots[pf+"eta_"+tag] = new TH1F(pf+"eta_"+tag,";Jet pseudo-rapidity;Events",50,-5,5);
+        allPlots[tag+pf+"pt"]  = new TH1F(tag+pf+"pt",";Jet transverse momentum [GeV];Events",50,0,250);
+        allPlots[tag+pf+"eta"] = new TH1F(tag+pf+"eta",";Jet pseudo-rapidity;Events",50,-5,5);
       }
-      allPlots["met_"+tag] = new TH1F("met_"+tag,";MET [GeV];Events",50,0,250);
+      allPlots[tag+"met"] = new TH1F(tag+"met",";MET [GeV];Events",50,0,250);
     }
   }
   
@@ -283,13 +283,14 @@ void RunTopJetShape(TString filename,
       }
       
       //event selected on reco level?
+      bool preselected          (true);
       bool singleLepton         ((chTag=="E" or chTag=="M") and
                                  (selector.getVetoLeptons().size() == 0));
       bool singleLepton4Jets    (singleLepton and jets.size()>=4);
       bool singleLepton4Jets2b  (singleLepton4Jets and sel_nbjets==2);
       bool singleLepton4Jets2b2W(singleLepton4Jets2b and sel_nwjets>0);
       
-      std::vector<bool> recoPass; recoPass.push_back(singleLepton); recoPass.push_back(singleLepton4Jets); recoPass.push_back(singleLepton4Jets2b); recoPass.push_back(singleLepton4Jets2b2W); 
+      std::vector<bool> recoPass; recoPass.push_back(preselected); recoPass.push_back(singleLepton); recoPass.push_back(singleLepton4Jets); recoPass.push_back(singleLepton4Jets2b); recoPass.push_back(singleLepton4Jets2b2W); 
       
       if (singleLepton4Jets2b2W) tjsev.reco_sel = 1;
       
@@ -303,12 +304,21 @@ void RunTopJetShape(TString filename,
       allPlots["puwgtctr"]->Fill(0.,1.0);
       if(!ev.isData) 
         {
+          // norm weight
+          wgt  = (normH? normH->GetBinContent(1) : 1.0);
+          
+          // pu weight
           float puWgt(puWgtGr[period][0]->Eval(ev.g_pu));
           allPlots["puwgtctr"]->Fill(1,puWgt);
-
-          wgt  = (normH? normH->GetBinContent(1) : 1.0);
           wgt *= puWgt;
+
+          // lhe weight
           wgt *= (ev.g_nw>0 ? ev.g_w[0] : 1.0);
+          
+          // lepton trigger*selection weight
+          double triggerCorrWgt = singleLepton ? lepEffH.getTriggerCorrection(leptons, period).first : 1.;
+          double lepSelCorrWgt  = singleLepton ? lepEffH.getOfflineCorrection(leptons[0], period).first : 1.;
+          wgt *= triggerCorrWgt*lepSelCorrWgt;
         }
       
       ////////////////////
@@ -348,32 +358,32 @@ void RunTopJetShape(TString filename,
           if (not recoPass[istage]) continue;
           if (channel == "E" and chTag != "E") continue;
           if (channel == "M" and chTag != "M") continue;
-          TString tag(stageVec[istage]+channel);
+          TString tag(channel+stageVec[istage]+"_");
           
           std::map<Int_t,Float_t>::iterator rIt=lumiMap.find(ev.run);
-          if(rIt!=lumiMap.end() && ratevsrunH) allPlots["ratevsrun_"+tag]->Fill(std::distance(lumiMap.begin(),rIt),1./rIt->second);
+          if(rIt!=lumiMap.end() && ratevsrunH) allPlots[tag+"ratevsrun"]->Fill(std::distance(lumiMap.begin(),rIt),1./rIt->second);
           
-          allPlots["nvtx_"+tag]->Fill(ev.nvtx, wgt);
-          allPlots["nleps_"+tag]->Fill(leptons.size(), wgt);
-          allPlots["njets_"+tag]->Fill(jets.size(), wgt);
-          allPlots["nbjets_"+tag]->Fill(sel_nbjets, wgt);
-          allPlots["nwjets_"+tag]->Fill(sel_nwjets, wgt);
-          for (auto& wCand : wCands) allPlots["wcandm_"+tag]->Fill(wCand.M(), wgt);
-          for (auto& tCand : tCands) allPlots["tcandm_"+tag]->Fill(tCand.M(), wgt);
-          for (auto& tCand : tCandsWcut) allPlots["tcandwcutm_"+tag]->Fill(tCand.M(), wgt);
+          allPlots[tag+"nvtx"]->Fill(ev.nvtx, wgt);
+          allPlots[tag+"nleps"]->Fill(leptons.size(), wgt);
+          allPlots[tag+"njets"]->Fill(jets.size(), wgt);
+          allPlots[tag+"nbjets"]->Fill(sel_nbjets, wgt);
+          allPlots[tag+"nwjets"]->Fill(sel_nwjets, wgt);
+          for (auto& wCand : wCands) allPlots[tag+"wcandm"]->Fill(wCand.M(), wgt);
+          for (auto& tCand : tCands) allPlots[tag+"tcandm"]->Fill(tCand.M(), wgt);
+          for (auto& tCand : tCandsWcut) allPlots[tag+"tcandwcutm"]->Fill(tCand.M(), wgt);
           for(unsigned int i=0; i<leptons.size(); i++) {
             if (i>1) break;
             TString pf(Form("l%d",i));          
-            allPlots[pf+"pt_"+tag] ->Fill(leptons[i].pt(),wgt);
-            allPlots[pf+"eta_"+tag]->Fill(leptons[i].eta(),wgt);
+            allPlots[tag+pf+"pt"] ->Fill(leptons[i].pt(),wgt);
+            allPlots[tag+pf+"eta"]->Fill(leptons[i].eta(),wgt);
           }
           for(unsigned int i=0; i<jets.size(); i++) {
             if (i>5) break;
             TString pf(Form("j%d",i));
-            allPlots[pf+"pt_"+tag] ->Fill(jets[i].pt(),wgt);
-            allPlots[pf+"eta_"+tag]->Fill(jets[i].eta(),wgt);
+            allPlots[tag+pf+"pt"] ->Fill(jets[i].pt(),wgt);
+            allPlots[tag+pf+"eta"]->Fill(jets[i].eta(),wgt);
           }
-          allPlots["met_"+tag]->Fill(ev.met_pt[0], wgt);
+          allPlots[tag+"met"]->Fill(ev.met_pt[0], wgt);
         }
       }
 

--- a/TopAnalysis/src/TOPJetShape.cc
+++ b/TopAnalysis/src/TOPJetShape.cc
@@ -42,6 +42,7 @@ void RunTopJetShape(TString filename,
 		    SelectionTool::FlavourSplitting flavourSplitting,
 		    TH1F *normH, 
 		    Bool_t runSysts,
+		    TString systVar,
 		    TString era,
 		    Bool_t debug)
 {
@@ -250,7 +251,7 @@ void RunTopJetShape(TString filename,
     {
       t->GetEntry(iev);
       resetTopJetShapeEvent(tjsev);
-      printf ("\r %i/%i [%3.0f%%] done", 100.*(float)iev/(float)nentries);
+      if(iev%10==0) printf ("\r [%3.0f%%] done", 100.*(float)iev/(float)nentries);
       
       //assign randomly a run period
       TString period = assignRunPeriod(runPeriods,random);

--- a/TopAnalysis/src/TOPJetShape.cc
+++ b/TopAnalysis/src/TOPJetShape.cc
@@ -237,6 +237,7 @@ void RunTopJetShape(TString filename,
   for (auto& it : allPlots)   { it.second->Sumw2(); it.second->SetDirectory(0); }
   for (auto& it : all2dPlots) { it.second->Sumw2(); it.second->SetDirectory(0); }
 
+  std::cout << "init done" << std::endl;
 
   ///////////////////////
   // LOOP OVER EVENTS //
@@ -249,7 +250,7 @@ void RunTopJetShape(TString filename,
     {
       t->GetEntry(iev);
       resetTopJetShapeEvent(tjsev);
-      if(iev%100==0) printf ("\r [%3.0f/100] done",100.*(float)(iev)/(float)(nentries));
+      printf ("\r %i/%i [%3.0f%%] done", 100.*(float)iev/(float)nentries);
       
       //assign randomly a run period
       TString period = assignRunPeriod(runPeriods,random);
@@ -328,7 +329,9 @@ void RunTopJetShape(TString filename,
         
         // lhe weights
         wgt *= (ev.g_nw>0 ? ev.g_w[0] : 1.0);
-        //TODO: add all variations (divided by default weight?)
+        for (int i = 1; i < ev.g_nw; ++i) {
+          varweights.push_back(ev.g_w[i]/ev.g_w[0]);
+        }
         
         tjsev.nw = 1 + varweights.size();
         tjsev.weight[0]=wgt;


### PR DESCRIPTION
This adds a option `--systVar` that takes a comma-separated list of systematic uncertainties, that are applied before final selection, like b-tagging and JEC uncertainties.
Additional output files are created that can be treated exactly like uncertainties from alternative MC samples.
The `--runSysts` option works well only for histogram-based analysis, as far as I can see.

+ some minor JetShape analysis changes