### PR TITLE
CTPPS "lite" local tracks added to the MiniEvent

### DIFF
--- a/TopAnalysis/interface/MiniEvent.h
+++ b/TopAnalysis/interface/MiniEvent.h
@@ -56,6 +56,11 @@ struct MiniEvent_t
   //Int_t pf_pvAssoc[5000],pf_vtxRef[5000];
   Float_t pf_pt[5000],pf_eta[5000],pf_phi[5000],pf_m[5000],pf_puppiWgt[5000];
   Float_t pf_dxy[5000],pf_dz[5000]; //pf_dxyUnc[5000],pf_dzUnc[5000];
+
+  //CTPPS leaves
+  Int_t nfwdtrk,fwdtrk_arm[50],fwdtrk_pot[50];
+  Float_t fwdtrk_x[50],fwdtrk_x_unc[50];
+  Float_t fwdtrk_y[50],fwdtrk_y_unc[50];
 };
 
 void createMiniEventTree(TTree *t,MiniEvent_t &ev);

--- a/TopAnalysis/plugins/BuildFile.xml
+++ b/TopAnalysis/plugins/BuildFile.xml
@@ -5,6 +5,8 @@
 <use name="FWCore/ServiceRegistry"/>
 <use name="DataFormats/VertexReco"/>
 <use name="DataFormats/PatCandidates"/>
+<use name="DataFormats/CTPPSReco"/>
+<use name="DataFormats/CTPPSDetId"/>
 <use name="DataFormats/Math"/>
 <use name="DataFormats/Common"/>
 <use name="CommonTools/UtilAlgos"/>

--- a/TopAnalysis/plugins/MiniAnalyzer.cc
+++ b/TopAnalysis/plugins/MiniAnalyzer.cc
@@ -44,6 +44,7 @@
 #include "DataFormats/PatCandidates/interface/PackedTriggerPrescales.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/CTPPSReco/interface/CTPPSLocalTrackLite.h"
+#include "DataFormats/CTPPSDetId/interface/CTPPSDetId.h"
 
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TopLJets2015/TopAnalysis/interface/MiniEvent.h"
@@ -506,12 +507,12 @@ int MiniAnalyzer::recAnalysis(const edm::Event& iEvent, const edm::EventSetup& i
     const CTPPSDetId detid(lt.getRPId());
     if (detid.station()!=0) continue; // only keep the 210m horizontal stations
 
-    fwdtrk_arm[ev_.nfwdtrk] = detid.arm(); // 0 = sector 4-5 ; 1 = sector 5-6
-    fwdtrk_pot[ev_.nfwdtrk] = detid.rp(); // 2 = near pot ; 3 = far pot
-    fwdtrk_x[ev_.nfwdtrk] = lt.getX()*1.e-3; // store in m
-    fwdtrk_x_unc[ev_.nfwdtrk] = lt.getXUnc()*1.e-3;
-    fwdtrk_y[ev_.nfwdtrk] = lt.getY()*1.e-3;
-    fwdtrk_y_unc[ev_.nfwdtrk] = lt.getYUnc()*1.e-3;
+    ev_.fwdtrk_arm[ev_.nfwdtrk] = detid.arm(); // 0 = sector 4-5 ; 1 = sector 5-6
+    ev_.fwdtrk_pot[ev_.nfwdtrk] = detid.rp(); // 2 = near pot ; 3 = far pot
+    ev_.fwdtrk_x[ev_.nfwdtrk] = lt.getX()*1.e-3; // store in m
+    ev_.fwdtrk_x_unc[ev_.nfwdtrk] = lt.getXUnc()*1.e-3;
+    ev_.fwdtrk_y[ev_.nfwdtrk] = lt.getY()*1.e-3;
+    ev_.fwdtrk_y_unc[ev_.nfwdtrk] = lt.getYUnc()*1.e-3;
 
     ev_.nfwdtrk++;
   }


### PR DESCRIPTION
This PR includes the various quantities associated to each track reconstructed in the horizontal Roman pots, namely:
* the side/arm and the associated RP where this local track is reconstructed
* the horizontal and vertical displacement of the tracks origin, and the associated uncertainties
